### PR TITLE
fix: console error

### DIFF
--- a/components/atoms/Logo/Logo.tsx
+++ b/components/atoms/Logo/Logo.tsx
@@ -32,13 +32,7 @@ const Logo = React.forwardRef<HTMLDivElement, LogoProps>(
           <span
             style={logoCssProperties as React.CSSProperties}
             className="h-[var(--logo-mobile-height)] w-[var(--logo-mobile-width)] lg:h-[var(--logo-desktop-height)] lg:w-[var(--logo-desktop-width)]">
-            <Image
-              alt="Logo"
-              src={logo.src}
-              layout="fill"
-              height={logo.height}
-              width={logo.width}
-            />
+            <Image alt="Logo" src={logo.src} layout="fill" />
           </span>
         ) : (
           <span className="text-3xl font-medium uppercase text-primary lg:text-5xl">

--- a/components/molecules/MegaMenu/MegaMenu.tsx
+++ b/components/molecules/MegaMenu/MegaMenu.tsx
@@ -26,12 +26,8 @@ const MegaMenu: React.FC<MegaMenuProps> = ({ items, ...props }) => {
 
   const getExpandedMenuItem = useCallback((item: NavItem, index: number) => {
     const defaultLink = (
-      <li>
-        <MenuLink
-          key={index}
-          item={item}
-          className="text-md font-normal text-primary"
-        />
+      <li key={index}>
+        <MenuLink item={item} className="text-md font-normal text-primary" />
       </li>
     );
 
@@ -40,9 +36,8 @@ const MegaMenu: React.FC<MegaMenuProps> = ({ items, ...props }) => {
         if (!item.value?.slug) return defaultLink;
 
         return (
-          <li>
+          <li key={index}>
             <CategoryDisplay
-              key={index}
               href={`/categories/${item.value?.slug}`}
               image={{
                 src: item.value?.images?.[0]?.file?.url ?? '',
@@ -60,9 +55,8 @@ const MegaMenu: React.FC<MegaMenuProps> = ({ items, ...props }) => {
         if (!item.value?.slug) return defaultLink;
 
         return (
-          <li>
+          <li key={index}>
             <ProductDisplay
-              key={index}
               product={{
                 id: item.value.id ?? '',
                 href: `/products/${item.value.slug}`,

--- a/components/molecules/PurchaseCard/PurchaseCard.tsx
+++ b/components/molecules/PurchaseCard/PurchaseCard.tsx
@@ -102,7 +102,7 @@ const PurchaseCard: React.FC<PurchaseCardProps> = ({
               key={image.alt + i}
               className="relative aspect-square md:h-full md:w-auto">
               <Image
-                {...image}
+                src={image.src}
                 layout="fill"
                 alt={image.alt}
                 className="rounded-lg"

--- a/components/organisms/AccountMobileMenu/AccountMobileMenu.tsx
+++ b/components/organisms/AccountMobileMenu/AccountMobileMenu.tsx
@@ -51,9 +51,13 @@ const AccountMobileMenu: React.FC<AccountMobileMenuProps> = ({
                         <ul className="flex flex-col gap-4">
                           {links.map(({ link, label }) => (
                             <li key={`${label}-${link}`}>
-                              <Disclosure.Button as={Link} href={link}>
-                                <a onClick={() => close()}>{label}</a>
-                              </Disclosure.Button>
+                              <Link href={link} passHref>
+                                <Disclosure.Button
+                                  as="a"
+                                  onClick={() => close()}>
+                                  {label}
+                                </Disclosure.Button>
+                              </Link>
                             </li>
                           ))}
                         </ul>

--- a/lib/utils/layout_getters.tsx
+++ b/lib/utils/layout_getters.tsx
@@ -1,7 +1,6 @@
-const MainLayout = dynamic(() => import('page_layouts/MainLayout'));
-const AccountLayout = dynamic(() => import('page_layouts/AccountLayout'));
-import dynamic from 'next/dynamic';
+import AccountLayout from 'page_layouts/AccountLayout';
 import AuthLayout from 'page_layouts/AuthLayout';
+import MainLayout from 'page_layouts/MainLayout';
 import type { ReactElement } from 'react';
 
 export const getMainLayout = (page: ReactElement) => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -240,20 +240,16 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     <>
       <ToastProvider>
         {getLayout(<Component {...pageProps} />)}
-        {!!notifications.length && (
-          <>
-            {notifications.map((notification) => (
-              <Notification
-                id={notification.id}
-                type={notification.type}
-                message={notification.message}
-                timeout={notification.timeout}
-                key={notification.id}
-              />
-            ))}
-            <ToastViewport className="fixed top-0 right-0 z-modal m-4 flex max-w-[500px] flex-col gap-2" />
-          </>
-        )}
+        {notifications.map((notification) => (
+          <Notification
+            id={notification.id}
+            type={notification.type}
+            message={notification.message}
+            timeout={notification.timeout}
+            key={notification.id}
+          />
+        ))}
+        <ToastViewport className="fixed top-0 right-0 z-modal m-4 flex max-w-[500px] flex-col gap-2" />
       </ToastProvider>
     </>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -240,16 +240,20 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     <>
       <ToastProvider>
         {getLayout(<Component {...pageProps} />)}
-        {notifications.map((notification) => (
-          <Notification
-            id={notification.id}
-            type={notification.type}
-            message={notification.message}
-            timeout={notification.timeout}
-            key={notification.id}
-          />
-        ))}
-        <ToastViewport className="fixed top-0 right-0 z-modal m-4 flex max-w-[500px] flex-col gap-2" />
+        {!!notifications.length && (
+          <>
+            {notifications.map((notification) => (
+              <Notification
+                id={notification.id}
+                type={notification.type}
+                message={notification.message}
+                timeout={notification.timeout}
+                key={notification.id}
+              />
+            ))}
+            <ToastViewport className="fixed top-0 right-0 z-modal m-4 flex max-w-[500px] flex-col gap-2" />
+          </>
+        )}
       </ToastProvider>
     </>
   );


### PR DESCRIPTION
[Console error > Expected server HTML to contain a matching ol in div](https://app.asana.com/0/1203417195444480/1203101322767840)

This PR:
- removes dynamic imports for layouts used in layout_getters. Since the layouts are wrappers around the application, inner components using browser features would cause a difference between server and client HTML, thus triggering the `Expected server HTML to contain a matching <div> in <div>`. 
- moves key to wrapping element instead of child to fix react "key" warnings in MegaMenu
- moves Disclouse.Button(in AccountMobileMenu) inside Link instead of rendering it as Link so onClick is not attached to Link. This fixes next/link warnings
- removes width/height from images using layout = fill to fix next/image warnings.