### PR TITLE
fix: make SubscriptionOptions click take effect right away

### DIFF
--- a/components/atoms/ScheduleLabel/ScheduleLabel.tsx
+++ b/components/atoms/ScheduleLabel/ScheduleLabel.tsx
@@ -27,7 +27,7 @@ export const ScheduleLabel: React.FC<ScheduleLabelProps> = ({
   if (!schedule) return null;
   const IconSvg = type === 'order' ? ShippingIcon : SyncIcon;
 
-  const Label = () => (
+  const label = (
     <span className={textClasses ?? ''}>
       {getScheduleLabel(base, schedule)}
     </span>
@@ -40,12 +40,12 @@ export const ScheduleLabel: React.FC<ScheduleLabelProps> = ({
           className ?? ''
         }`}>
         <IconSvg className={iconClasses ?? ''} />
-        <Label />
+        {label}
       </div>
     );
   }
 
-  return <Label />;
+  return label;
 };
 
 export default ScheduleLabel;

--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -194,6 +194,19 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
     isGiftCard,
     stockLevel,
   });
+  const standardPriceTotal = activeVariation?.standardPrice?.price
+    ? activeVariation?.standardPrice?.price * state.quantity
+    : 0;
+  const subscriptionPriceTotal = activeVariation?.subscriptionPrice?.price
+    ? activeVariation?.subscriptionPrice?.price * state.quantity
+    : 0;
+  const origStandardPriceTotal = activeVariation?.standardPrice?.origPrice
+    ? activeVariation?.standardPrice?.origPrice * state.quantity
+    : undefined;
+  const origSubscriptionPriceTotal = activeVariation?.subscriptionPrice
+    ?.origPrice
+    ? activeVariation?.subscriptionPrice?.origPrice * state.quantity
+    : undefined;
 
   const [stockStatus, maxQuantity] = useProductStock({
     stockTracking,
@@ -364,13 +377,13 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
                   {state.selectedPurchaseOption ===
                   PURCHASE_OPTION_TYPE.SUBSCRIPTION ? (
                     <Price
-                      price={activeVariation?.subscriptionPrice?.price ?? 0}
-                      origPrice={activeVariation?.subscriptionPrice?.origPrice}
+                      price={subscriptionPriceTotal}
+                      origPrice={origSubscriptionPriceTotal}
                     />
                   ) : (
                     <Price
-                      price={activeVariation?.standardPrice?.price ?? 0}
-                      origPrice={activeVariation?.standardPrice?.origPrice}
+                      price={standardPriceTotal}
+                      origPrice={origStandardPriceTotal}
                     />
                   )}
                 </Button>


### PR DESCRIPTION
[QA > Takes two clicks to select a subscription option](https://app.asana.com/0/1202388930598302/1203258222606732)

This PR:
- replaces Label component inside ScheduleLabel with a variable. It was hard to find why this would cause to have to click twice on the SubscriptionOptions list item as in the end both would return the same output in the DOM, a <span></span>. Defining a component inside another component is not a good practice anyways as that's causing the inner component to re-created on each render.

Here's a video with before and after:

https://user-images.githubusercontent.com/107462252/206450837-eb2d39e5-642b-4548-b5cf-0bf6975770bb.mov


