### PR TITLE
fix: use priceTotal for cart item

### DIFF
--- a/components/atoms/Price/Price.test.tsx
+++ b/components/atoms/Price/Price.test.tsx
@@ -5,14 +5,14 @@ import '@testing-library/jest-dom/extend-expect';
 describe('Price', () => {
   it('should format the price correctly', () => {
     render(<Price price={10.5} />);
-    expect(screen.getByText('$10.50')).toBeVisible();
+    expect(screen.getByText('US$10.50')).toBeVisible();
   });
 
   it('should render the formatted sale price correctly', () => {
     render(<Price price={100} origPrice={200} />);
-    expect(screen.getByText('$100.00')).toBeVisible();
-    expect(screen.getByText('$200.00')).toBeVisible();
-    expect(screen.getByText('$200.00')).toHaveClass('line-through');
+    expect(screen.getByText('US$100.00')).toBeVisible();
+    expect(screen.getByText('US$200.00')).toBeVisible();
+    expect(screen.getByText('US$200.00')).toHaveClass('line-through');
   });
 
   it('should format the subscription price correctly', () => {
@@ -25,7 +25,7 @@ describe('Price', () => {
         }}
       />,
     );
-    expect(screen.getByText('$51.20/2mo')).toBeVisible();
+    expect(screen.getByText('US$51.20/2mo')).toBeVisible();
   });
 
   it('should render the subscription sale price correctly', () => {
@@ -39,8 +39,8 @@ describe('Price', () => {
         }}
       />,
     );
-    expect(screen.getByText('$101.91/2mo')).toBeVisible();
-    expect(screen.getByText('$204.02/2mo')).toBeVisible();
-    expect(screen.getByText('$204.02/2mo')).toHaveClass('line-through');
+    expect(screen.getByText('US$101.91/2mo')).toBeVisible();
+    expect(screen.getByText('US$204.02/2mo')).toBeVisible();
+    expect(screen.getByText('US$204.02/2mo')).toHaveClass('line-through');
   });
 });

--- a/components/molecules/CartItem/CartItem.stories.tsx
+++ b/components/molecules/CartItem/CartItem.stories.tsx
@@ -20,6 +20,7 @@ Default.args = {
   title: 'Vitamin D',
   href: '/products/vitamin-d',
   price: 10,
+  priceTotal: 100,
   image: {
     src: '/images/product-preview-card-1.webp',
     width: 1072,

--- a/components/molecules/CartItem/CartItem.tsx
+++ b/components/molecules/CartItem/CartItem.tsx
@@ -29,6 +29,7 @@ export interface CartItemProps {
   image: MandatoryImageProps;
   title: string;
   price: number;
+  priceTotal: number;
   quantity: number;
   minQuantity: number;
   purchaseOption: Maybe<SwellCartItemPurchaseOption>;
@@ -47,6 +48,7 @@ const CartItem: React.FC<CartItemProps> = ({
   title,
   image,
   price,
+  priceTotal,
   quantity,
   minQuantity = 1,
   purchaseOption,
@@ -70,6 +72,10 @@ const CartItem: React.FC<CartItemProps> = ({
 
   const [quantityInputValue, setQuantityInputValue] = useState(quantity);
   const debounceTimeout = useRef<ReturnType<typeof setTimeout> | undefined>();
+
+  // Price to be shown in the trial text. We can't use priceTotal
+  // because that will return the price for the first order, which is 0
+  const afterTrialPrice = useMemo(() => price * quantity, [price, quantity]);
 
   useEffect(() => {
     // Ignore quantity changes if the user is changing the input value
@@ -165,16 +171,16 @@ const CartItem: React.FC<CartItemProps> = ({
             {hasTrial ? (
               <>
                 <span className="text-sm font-semibold text-primary">
-                  <Price price={0} origPrice={price} />
+                  <Price price={0} origPrice={afterTrialPrice} />
                 </span>
                 <TrialLabel
                   trialDays={purchaseOption?.billingSchedule?.trialDays}
-                  price={price}
+                  price={afterTrialPrice}
                 />
               </>
             ) : (
               <span className="text-sm font-semibold text-primary">
-                <Price price={price} />
+                <Price price={priceTotal} />
               </span>
             )}
           </span>

--- a/components/organisms/Cart/Cart.stories.tsx
+++ b/components/organisms/Cart/Cart.stories.tsx
@@ -31,6 +31,7 @@ Default.args = {
       title: 'Vitamin D',
       href: '/products/vitamin-d',
       price: 10,
+      priceTotal: 50,
       image: {
         src: '/images/product-preview-card-1.webp',
         width: 1072,
@@ -48,6 +49,7 @@ Default.args = {
       title: 'Vitamin D',
       href: '/products/vitamin-d',
       price: 20,
+      priceTotal: 100,
       image: {
         src: '/images/product-preview-card-1.webp',
         width: 1072,
@@ -65,6 +67,7 @@ Default.args = {
       title: 'Vitamin D',
       href: '/products/vitamin-d',
       price: 10,
+      priceTotal: 100,
       image: {
         src: '/images/product-preview-card-1.webp',
         width: 1072,
@@ -82,6 +85,7 @@ Default.args = {
       title: 'Vitamin D',
       href: '/products/vitamin-d',
       price: 20,
+      priceTotal: 100,
       image: {
         src: '/images/product-preview-card-1.webp',
         width: 1072,
@@ -99,6 +103,7 @@ Default.args = {
       title: 'Vitamin D',
       href: '/products/vitamin-d',
       price: 10,
+      priceTotal: 100,
       image: {
         src: '/images/product-preview-card-1.webp',
         width: 1072,
@@ -116,6 +121,7 @@ Default.args = {
       title: 'Vitamin D',
       href: '/products/vitamin-d',
       price: 20,
+      priceTotal: 100,
       image: {
         src: '/images/product-preview-card-1.webp',
         width: 1072,

--- a/lib/utils/cart.ts
+++ b/lib/utils/cart.ts
@@ -8,6 +8,7 @@ export const getCartItems = (cart: SwellCart) =>
           id: item.id ?? '',
           title: item.product?.name ?? '',
           price: item.price ?? 0,
+          priceTotal: item.priceTotal ?? 0,
           quantity: item.quantity ?? 1,
           minQuantity: 1,
           href: `/products/${item.product?.slug}`,

--- a/stores/cart.test.ts
+++ b/stores/cart.test.ts
@@ -14,6 +14,7 @@ const cartItems: CartItemProps[] = [
       src: 'https://placekitten.com/100/100',
     },
     price: 10,
+    priceTotal: 10,
     productOptions: [
       {
         id: 'abc',


### PR DESCRIPTION
In this PR:
- use priceTotal instead of price to reflect the quantity multiplier in the cart item
- add afterTrialPrice to reflect the total price after trial period ends
- fix expected currency display in Price.test from $ to US$