### PR TITLE
fix: add missing source to content schemas

### DIFF
--- a/config/content/category.json
+++ b/config/content/category.json
@@ -63,5 +63,7 @@
       "label": "Enable quick add",
       "type": "toggle"
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/divider.json
+++ b/config/content/divider.json
@@ -42,5 +42,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/full_width_media.json
+++ b/config/content/full_width_media.json
@@ -233,5 +233,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/heading_with_text.json
+++ b/config/content/heading_with_text.json
@@ -213,5 +213,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/memberships.json
+++ b/config/content/memberships.json
@@ -153,5 +153,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/multiple_features.json
+++ b/config/content/multiple_features.json
@@ -170,5 +170,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/multiple_panels.json
+++ b/config/content/multiple_panels.json
@@ -364,5 +364,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/page.json
+++ b/config/content/page.json
@@ -17,5 +17,7 @@
         "divider"
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/press_mentions_carousel.json
+++ b/config/content/press_mentions_carousel.json
@@ -69,5 +69,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/product.json
+++ b/config/content/product.json
@@ -96,5 +96,7 @@
       ],
       "admin_zone": "content"
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/products_preview.json
+++ b/config/content/products_preview.json
@@ -113,5 +113,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }

--- a/config/content/reviews.json
+++ b/config/content/reviews.json
@@ -144,5 +144,7 @@
         }
       ]
     }
-  ]
+  ],
+  "source_type": "theme",
+  "source_id": "horizon"
 }


### PR DESCRIPTION
Schemas missing the `source` fields were not correctly namespaced.

Before adding
![image](https://user-images.githubusercontent.com/8879183/208197713-274fd77a-0e98-4a95-9a54-f4657451695a.png)

After adding
![image](https://user-images.githubusercontent.com/8879183/208197733-866cf98b-b0de-441c-b3a0-e4ae640d76ef.png)

The `theme.horizon` prefix is now consistently appearing.