### PR TITLE
fix: US dollar is hardcoded in the Horizon theme

### DIFF
--- a/lib/shop/fetchingFunctions.ts
+++ b/lib/shop/fetchingFunctions.ts
@@ -20,7 +20,7 @@ import type { QuizResultsProducts } from 'components/molecules/QuizResults';
 import { hasQuickAdd, mapProducts } from 'lib/utils/products';
 import {
   formatCurrencies,
-  formatCurrency,
+  getCurrencyFromSettings,
   formatLocales,
   formatStoreSettings,
 } from 'utils/settings';
@@ -389,7 +389,7 @@ export const getStoreSettings = async (locale?: string) => {
   ]);
 
   const currencies = formatCurrencies(storeData.data.storeSettings);
-  const currency = formatCurrency(storeData.data.storeSettings);
+  const currency = getCurrencyFromSettings(storeData.data.storeSettings);
 
   return {
     ...formatStoreSettings(

--- a/lib/shop/fetchingFunctions.ts
+++ b/lib/shop/fetchingFunctions.ts
@@ -20,6 +20,7 @@ import type { QuizResultsProducts } from 'components/molecules/QuizResults';
 import { hasQuickAdd, mapProducts } from 'lib/utils/products';
 import {
   formatCurrencies,
+  formatCurrency,
   formatLocales,
   formatStoreSettings,
 } from 'utils/settings';
@@ -387,12 +388,16 @@ export const getStoreSettings = async (locale?: string) => {
     client.getMenus(),
   ]);
 
+  const currencies = formatCurrencies(storeData.data.storeSettings);
+  const currency = formatCurrency(storeData.data.storeSettings);
+
   return {
     ...formatStoreSettings(
       storeData.data.storeSettings,
       menusData.data.menuSettings,
     ),
     locales: formatLocales(storeData.data.storeSettings),
-    currencies: formatCurrencies(storeData.data.storeSettings),
+    currencies,
+    currency,
   };
 };

--- a/lib/utils/fetch_decorators.ts
+++ b/lib/utils/fetch_decorators.ts
@@ -30,9 +30,8 @@ export function withMainLayout<C extends GetProps<unknown>>(callback: C) {
       return result;
     }
 
-    const { currencies, locales, ...settings } = await getStoreSettings(
-      result.props.locale,
-    );
+    const { currencies, currency, locales, ...settings } =
+      await getStoreSettings(result.props.locale);
 
     return {
       ...result,
@@ -42,6 +41,7 @@ export function withMainLayout<C extends GetProps<unknown>>(callback: C) {
           settings,
           locales,
           currencies,
+          currency,
         },
       },
     };

--- a/page_layouts/MainLayout.tsx
+++ b/page_layouts/MainLayout.tsx
@@ -13,12 +13,14 @@ export interface MainLayoutProps {
   settings: Settings;
   locales: Locale[];
   currencies: Currency[];
+  currency: Currency;
 }
 
 const MainLayout: React.FC<MainLayoutProps> = ({
   children,
   settings,
   currencies,
+  currency,
   locales,
 }) => {
   const cart = useCartStore((store) => store.cart);
@@ -30,6 +32,8 @@ const MainLayout: React.FC<MainLayoutProps> = ({
       state.settings?.footer,
       state.settings?.socialLinks,
     ]);
+
+  const setCurrency = useCurrencyStore((state) => state.setCurrency);
   const setCurrencies = useCurrencyStore((state) => state.setCurrencies);
   const setLocales = useLocaleStore((state) => state.setLocales);
 
@@ -38,9 +42,19 @@ const MainLayout: React.FC<MainLayoutProps> = ({
     if (settings && currencies && locales) {
       setSettings(settings);
       setCurrencies(currencies);
+      setCurrency(currency);
       setLocales(locales);
     }
-  }, [setSettings, setCurrencies, setLocales, settings, currencies, locales]);
+  }, [
+    setSettings,
+    setCurrencies,
+    setCurrency,
+    setLocales,
+    settings,
+    currencies,
+    currency,
+    locales,
+  ]);
 
   return (
     <div>

--- a/utils/settings.test.ts
+++ b/utils/settings.test.ts
@@ -1,0 +1,52 @@
+import { formatCurrency } from './settings';
+
+describe('formatCurrency', () => {
+  it('should return the correct currency object with defined store.currencies and store.currency', () => {
+    const settings = {
+      store: {
+        currencies: [
+          { code: 'USD', symbol: '$' },
+          { code: 'EUR', symbol: '€' },
+        ],
+        currency: 'EUR',
+      },
+    };
+    const result = formatCurrency(settings);
+
+    expect(result).toEqual({ code: 'EUR', symbol: '€' });
+  });
+
+  it('should return the default currency object with undefined store.currency', () => {
+    const settings = {
+      store: {
+        currencies: [
+          { code: 'USD', symbol: '$' },
+          { code: 'EUR', symbol: '€' },
+        ],
+      },
+    };
+    const result = formatCurrency(settings);
+
+    expect(result).toEqual({ code: 'USD' });
+  });
+
+  it('should return the default currency object when store.currencies is undefined', () => {
+    const settings = {
+      store: {
+        currency: 'EUR',
+      },
+    };
+    const result = formatCurrency(settings);
+
+    expect(result).toEqual({ code: 'EUR' });
+  });
+
+  it('should return the default currency object when store.currencies and store.currency are undefined', () => {
+    const settings = {
+      store: {},
+    };
+    const result = formatCurrency(settings);
+
+    expect(result).toEqual({ code: 'USD' });
+  });
+});

--- a/utils/settings.test.ts
+++ b/utils/settings.test.ts
@@ -1,6 +1,6 @@
-import { formatCurrency } from './settings';
+import { getCurrencyFromSettings } from './settings';
 
-describe('formatCurrency', () => {
+describe('getCurrencyFromSettings', () => {
   it('should return the correct currency object with defined store.currencies and store.currency', () => {
     const settings = {
       store: {
@@ -11,7 +11,7 @@ describe('formatCurrency', () => {
         currency: 'EUR',
       },
     };
-    const result = formatCurrency(settings);
+    const result = getCurrencyFromSettings(settings);
 
     expect(result).toEqual({ code: 'EUR', symbol: '€' });
   });
@@ -25,7 +25,7 @@ describe('formatCurrency', () => {
         ],
       },
     };
-    const result = formatCurrency(settings);
+    const result = getCurrencyFromSettings(settings);
 
     expect(result).toEqual({ code: 'USD' });
   });
@@ -36,7 +36,7 @@ describe('formatCurrency', () => {
         currency: 'EUR',
       },
     };
-    const result = formatCurrency(settings);
+    const result = getCurrencyFromSettings(settings);
 
     expect(result).toEqual({ code: 'EUR' });
   });
@@ -45,7 +45,7 @@ describe('formatCurrency', () => {
     const settings = {
       store: {},
     };
-    const result = formatCurrency(settings);
+    const result = getCurrencyFromSettings(settings);
 
     expect(result).toEqual({ code: 'USD' });
   });

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -172,7 +172,9 @@ export const getCurrencyFromSettings = (settings: any) => {
     return { code: store?.currency || 'USD' };
   }
 
-  const currency = store.currencies.find(({ code }) => code === store.currency);
+  const currency = store.currencies.find(
+    ({ code }: { code: string }) => code === store.currency,
+  );
 
   return currency || { code: store.currency };
 };

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -165,6 +165,18 @@ export const formatCurrencies = (settings: any): Currency[] =>
     })
     .filter(isNotNull) ?? [];
 
+export const formatCurrency = (settings: any) => {
+  const { store } = settings;
+
+  if (!store?.currencies || !store.currency) {
+    return { code: store?.currency || 'USD' };
+  }
+
+  const currency = store.currencies.find(({ code }) => code === store.currency);
+
+  return currency || { code: store.currency };
+};
+
 export const formatAccountHeaderSettings = (settings: Settings | null) =>
   settings
     ? {

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -165,7 +165,7 @@ export const formatCurrencies = (settings: any): Currency[] =>
     })
     .filter(isNotNull) ?? [];
 
-export const formatCurrency = (settings: any) => {
+export const getCurrencyFromSettings = (settings: any) => {
   const { store } = settings;
 
   if (!store?.currencies || !store.currency) {


### PR DESCRIPTION
Issue link:  [US dollar is hardcoded in the Horizon theme](https://app.asana.com/0/1202306318068147/1204807511099241/f)

This happened because we didn't change the store's currency to the one that was set in the admin panel.

https://github.com/swellstores/horizon/assets/145032708/3453dc3d-99fa-4b21-a8d3-1eb060ea0e12

