### PR TITLE
The return to login link is incorrect in Horizon

### DIFF
--- a/pages/account/password-recovery/check-email.tsx
+++ b/pages/account/password-recovery/check-email.tsx
@@ -33,12 +33,14 @@ const CheckEmailPage: NextPageWithLayout<PageProps> = ({
   const router = useRouter();
   const i18n = useI18n();
   const text = checkEmailText(i18n);
+  const loginLinkHref = `${
+    router.locale !== router.defaultLocale ? `/${router.locale}` : ''
+  }/account/login`;
+
   const backToLoginText = i18n(
     'account.password_recovery.check_email.back_to_login_text',
     {
-      loginLink: `<a class="font-bold hover:underline" href='/${
-        router.locale !== router.defaultLocale ? `${router.locale}/` : ''
-      }/account/login'>${text.backToLoginLink}</a>`,
+      loginLink: `<a class="font-bold hover:underline" href='${loginLinkHref}'>${text.backToLoginLink}</a>`,
     },
   );
 

--- a/pages/account/password-recovery/index.tsx
+++ b/pages/account/password-recovery/index.tsx
@@ -226,10 +226,6 @@ const PasswordRecoveryPage: NextPageWithLayout<PageProps> = ({
                 className="mt-4 text-center text-sm text-primary md:mt-6"
                 dangerouslySetInnerHTML={{ __html: backToLoginText }}
               />
-
-              <div>
-                {router.locale}, {router.defaultLocale}, {router.locale}
-              </div>
             </div>
           </div>
         </fieldset>

--- a/pages/account/password-recovery/index.tsx
+++ b/pages/account/password-recovery/index.tsx
@@ -63,10 +63,12 @@ const PasswordRecoveryPage: NextPageWithLayout<PageProps> = ({
   const otherError = error?.field === ACCOUNT_FIELD.OTHER;
   const emailError = error?.field === ACCOUNT_FIELD.EMAIL || otherError;
   const emailInputRef = useRef<HTMLInputElement>(null);
+  const loginLinkHref = `${
+    router.locale !== router.defaultLocale ? `/${router.locale}` : ''
+  }/account/login`;
+
   const backToLoginText = i18n('account.password_recovery.back_to_login_text', {
-    loginLink: `<a class="font-bold hover:underline" href='/${
-      router.locale !== router.defaultLocale ? `${router.locale}/` : ''
-    }/account/login'>${text.backToLoginLink}</a>`,
+    loginLink: `<a class="font-bold hover:underline" href='${loginLinkHref}'>${text.backToLoginLink}</a>`,
   });
   const responseCallback = useCallback(
     (res: Response) => {
@@ -224,6 +226,10 @@ const PasswordRecoveryPage: NextPageWithLayout<PageProps> = ({
                 className="mt-4 text-center text-sm text-primary md:mt-6"
                 dangerouslySetInnerHTML={{ __html: backToLoginText }}
               />
+
+              <div>
+                {router.locale}, {router.defaultLocale}, {router.locale}
+              </div>
             </div>
           </div>
         </fieldset>


### PR DESCRIPTION
The problem occurred because we had incorrectly set the "/" characters in urls

https://github.com/swellstores/horizon/assets/145032708/a3a2a19e-447e-4f0d-8151-66372710d462

